### PR TITLE
Add standalone newsletter admin interface

### DIFF
--- a/newsletter/models.py
+++ b/newsletter/models.py
@@ -8,8 +8,10 @@ from zoneinfo import ZoneInfo
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.template import Context, Engine
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.html import strip_tags
 from django.utils.translation import gettext_lazy as _
 from wagtail.admin.panels import FieldPanel, MultiFieldPanel
 from wagtail.fields import RichTextField
@@ -54,6 +56,20 @@ class EmailTemplate(TimeStampedModel):
 
     def __str__(self) -> str:
         return self.name
+
+    def render_plain_text(self, context: Optional[dict] = None) -> str:
+        """Render a plain-text version of the template for sending."""
+
+        engine = Engine.get_default()
+        ctx = Context(context or {})
+
+        if self.text_body:
+            template = engine.from_string(self.text_body)
+            return template.render(ctx).strip()
+
+        html_template = engine.from_string(str(self.html_body))
+        rendered_html = html_template.render(ctx)
+        return strip_tags(rendered_html).strip()
 
 
 @register_snippet
@@ -239,6 +255,14 @@ class Campaign(TimeStampedModel):
 
     def __str__(self) -> str:
         return self.name
+
+    def render_plain_text(self, context: Optional[dict] = None) -> str:
+        """Render the campaign's content to plain text."""
+
+        base_context = {"campaign": self}
+        if context:
+            base_context.update(context)
+        return self.email_template.render_plain_text(base_context)
 
     def get_from_email(self) -> str:
         custom = next(

--- a/newsletter/services.py
+++ b/newsletter/services.py
@@ -7,7 +7,6 @@ from django.conf import settings
 from django.template import Context, Engine
 from django.template.loader import render_to_string
 from django.utils import timezone
-from django.utils.html import strip_tags
 
 from .models import (
     Campaign,
@@ -31,12 +30,10 @@ def _get_engine() -> Engine:
 
 def render_email_parts(template: EmailTemplate, context: dict) -> tuple[str, str, str]:
     engine = _get_engine()
-    subject = engine.from_string(template.subject_template).render(Context(context)).strip()
-    html_body = engine.from_string(template.html_body).render(Context(context))
-    if template.text_body:
-        text_body = engine.from_string(template.text_body).render(Context(context))
-    else:
-        text_body = strip_tags(html_body)
+    context_obj = Context(context)
+    subject = engine.from_string(template.subject_template).render(context_obj).strip()
+    html_body = engine.from_string(str(template.html_body)).render(context_obj)
+    text_body = template.render_plain_text(context)
     return subject, html_body, text_body
 
 

--- a/newsletter/templates/newsletter/admin/base.html
+++ b/newsletter/templates/newsletter/admin/base.html
@@ -1,0 +1,345 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}{{ page_title|default:"Newsletter admin" }} · Aquiles Newsletter{% endblock %}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --surface: #0f172a;
+            --surface-muted: #1e293b;
+            --surface-soft: #27364e;
+            --text: #0f172a;
+            --text-muted: #55627a;
+            --primary: #6366f1;
+            --primary-soft: rgba(99, 102, 241, 0.14);
+            --border: #e2e8f0;
+            --background: #f8fafc;
+            --success: #16a34a;
+            --danger: #dc2626;
+            --warning: #f59e0b;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            margin: 0;
+            background: var(--background);
+            color: var(--text);
+        }
+
+        a {
+            color: inherit;
+        }
+
+        .layout {
+            min-height: 100vh;
+            display: grid;
+            grid-template-columns: 260px 1fr;
+            background: linear-gradient(135deg, rgba(99,102,241,0.04), rgba(14,165,233,0.04));
+        }
+
+        @media (max-width: 980px) {
+            .layout {
+                grid-template-columns: 1fr;
+            }
+            .sidebar {
+                position: sticky;
+                top: 0;
+                z-index: 10;
+                display: flex;
+                flex-direction: row;
+                overflow-x: auto;
+            }
+            .sidebar nav {
+                flex-direction: row;
+                gap: 0.75rem;
+            }
+            .main {
+                padding-left: 0;
+            }
+        }
+
+        .sidebar {
+            background: linear-gradient(165deg, var(--surface), var(--surface-muted));
+            color: white;
+            padding: 2rem 1.75rem;
+            display: flex;
+            flex-direction: column;
+            gap: 2rem;
+            box-shadow: inset -1px 0 0 rgba(148, 163, 184, 0.1);
+        }
+
+        .brand {
+            font-size: 1.35rem;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+        }
+
+        .sidebar nav {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .nav-link {
+            display: block;
+            padding: 0.65rem 0.9rem;
+            border-radius: 12px;
+            font-weight: 500;
+            color: rgba(255,255,255,0.78);
+            text-decoration: none;
+            transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+        }
+
+        .nav-link:hover {
+            background: rgba(255,255,255,0.12);
+            color: white;
+            transform: translateX(2px);
+        }
+
+        .nav-link.active {
+            background: rgba(255,255,255,0.22);
+            color: white;
+            box-shadow: 0 12px 28px -18px rgba(15, 23, 42, 0.7);
+        }
+
+        .main {
+            padding: 2.5rem 3rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+        }
+
+        .topbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+        }
+
+        .topbar h1 {
+            margin: 0;
+            font-size: 2rem;
+            font-weight: 600;
+            color: #0f172a;
+        }
+
+        .content {
+            background: white;
+            border-radius: 24px;
+            padding: 2rem;
+            box-shadow: 0 25px 50px -20px rgba(15, 23, 42, 0.1);
+        }
+
+        .messages {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            margin-bottom: 1.5rem;
+        }
+
+        .message {
+            padding: 0.85rem 1rem;
+            border-radius: 12px;
+            font-weight: 500;
+        }
+
+        .message-success {
+            background: rgba(22, 163, 74, 0.12);
+            color: #166534;
+        }
+
+        .message-error {
+            background: rgba(220, 38, 38, 0.12);
+            color: #b91c1c;
+        }
+
+        .message-warning {
+            background: rgba(245, 158, 11, 0.15);
+            color: #b45309;
+        }
+
+        .message-info {
+            background: rgba(79, 70, 229, 0.15);
+            color: #3730a3;
+        }
+
+        .page-section {
+            display: flex;
+            flex-direction: column;
+            gap: 1.5rem;
+        }
+
+        .section-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            gap: 1rem;
+        }
+
+        .section-header h2 {
+            margin: 0;
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: var(--text);
+        }
+
+        .muted {
+            color: var(--text-muted);
+            font-size: 0.95rem;
+        }
+
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.35rem;
+            font-size: 0.8rem;
+            font-weight: 600;
+            padding: 0.25rem 0.6rem;
+            border-radius: 999px;
+            background: var(--primary-soft);
+            color: var(--primary);
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        th {
+            text-align: left;
+            padding: 0.75rem 0.9rem;
+            font-size: 0.85rem;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            color: var(--text-muted);
+            border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+            background: rgba(148, 163, 184, 0.08);
+        }
+
+        td {
+            padding: 0.85rem 0.9rem;
+            border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+            vertical-align: top;
+        }
+
+        tbody tr:hover {
+            background: rgba(99, 102, 241, 0.05);
+        }
+
+        .button {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 0.55rem 1.1rem;
+            border-radius: 999px;
+            border: none;
+            cursor: pointer;
+            font-weight: 600;
+            font-size: 0.9rem;
+            text-decoration: none;
+            transition: transform 0.15s ease, box-shadow 0.15s ease;
+        }
+
+        .button-primary {
+            background: linear-gradient(135deg, #6366f1, #4f46e5);
+            color: white;
+            box-shadow: 0 12px 20px -15px rgba(79, 70, 229, 0.6);
+        }
+
+        .button-secondary {
+            background: rgba(99, 102, 241, 0.1);
+            color: #3730a3;
+        }
+
+        .button-muted {
+            background: rgba(15, 23, 42, 0.05);
+            color: var(--text-muted);
+        }
+
+        .button:hover {
+            transform: translateY(-1px);
+        }
+
+        .input, textarea, select {
+            width: 100%;
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 184, 0.4);
+            padding: 0.6rem 0.75rem;
+            font-size: 0.95rem;
+            font-family: inherit;
+            background: white;
+            transition: border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .input:focus, textarea:focus, select:focus {
+            outline: none;
+            border-color: var(--primary);
+            box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+        }
+
+        .form-grid {
+            display: grid;
+            gap: 1rem;
+        }
+
+        .form-grid.two-column {
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        .form-field label {
+            display: block;
+            font-weight: 600;
+            font-size: 0.9rem;
+            margin-bottom: 0.4rem;
+            color: var(--text);
+        }
+
+        .empty-state {
+            padding: 2rem;
+            text-align: center;
+            border: 2px dashed rgba(148, 163, 184, 0.25);
+            border-radius: 16px;
+            color: var(--text-muted);
+        }
+    </style>
+    {% block extra_head %}{% endblock %}
+</head>
+<body>
+<div class="layout">
+    <aside class="sidebar">
+        <div class="brand">Newsletter Studio</div>
+        <nav>
+            {% for item in admin_nav %}
+                <a class="nav-link{% if item.slug == active_section %} active{% endif %}" href="{{ item.url }}">{{ item.label }}</a>
+            {% endfor %}
+        </nav>
+    </aside>
+    <main class="main">
+        <header class="topbar">
+            <h1>{{ page_title }}</h1>
+            {% block actions %}{% endblock %}
+        </header>
+        <div class="content">
+            {% if messages %}
+                <div class="messages">
+                    {% for message in messages %}
+                        <div class="message message-{{ message.tags|default:'info' }}">{{ message }}</div>
+                    {% endfor %}
+                </div>
+            {% endif %}
+            {% block content %}{% endblock %}
+        </div>
+    </main>
+</div>
+{% block extra_js %}{% endblock %}
+</body>
+</html>

--- a/newsletter/templates/newsletter/admin/campaigns.html
+++ b/newsletter/templates/newsletter/admin/campaigns.html
@@ -1,0 +1,266 @@
+{% extends "newsletter/admin/base.html" %}
+{% load i18n %}
+
+{% block title %}{{ page_title }} · Aquiles Newsletter{% endblock %}
+
+{% block extra_head %}
+<style>
+    .split-grid {
+        display: grid;
+        gap: 2rem;
+        grid-template-columns: minmax(280px, 360px) 1fr;
+    }
+
+    @media (max-width: 980px) {
+        .split-grid {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    .panel {
+        border-radius: 18px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        padding: 1.5rem;
+        background: rgba(255,255,255,0.95);
+        box-shadow: 0 18px 40px -25px rgba(15, 23, 42, 0.2);
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .panel header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-end;
+    }
+
+    .panel header h2 {
+        margin: 0;
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: #0f172a;
+    }
+
+    .status-chip {
+        display: inline-flex;
+        padding: 0.25rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        background: rgba(99, 102, 241, 0.1);
+        color: #3730a3;
+    }
+
+    .campaign-table tbody tr td:last-child {
+        width: 160px;
+    }
+
+    .table-actions {
+        display: inline-flex;
+        gap: 0.4rem;
+    }
+
+    .table-actions form {
+        display: inline;
+    }
+
+    .button-small {
+        padding: 0.35rem 0.75rem;
+        font-size: 0.8rem;
+    }
+
+    .pagination {
+        margin-top: 1rem;
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.6rem;
+        align-items: center;
+        font-size: 0.9rem;
+    }
+
+    .pagination a {
+        text-decoration: none;
+        color: var(--primary);
+        font-weight: 600;
+    }
+
+    .help-text {
+        font-size: 0.85rem;
+        color: var(--text-muted);
+    }
+
+    .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+    }
+
+    .tag {
+        padding: 0.2rem 0.55rem;
+        border-radius: 999px;
+        background: rgba(15, 23, 42, 0.06);
+        font-size: 0.75rem;
+        font-weight: 500;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="page-section">
+    <div class="section-header">
+        <div>
+            <p class="muted">{% trans "Manage campaigns, review status and schedule upcoming sends." %}</p>
+        </div>
+        <div class="pill">
+            {% trans "Status" %} ·
+            {% for item in status_summary %}
+                {{ item.label }}: {{ item.count }}{% if not forloop.last %} · {% endif %}
+            {% endfor %}
+        </div>
+    </div>
+
+    <div class="split-grid">
+        <section class="panel">
+            <header>
+                <h2>
+                    {% if current_campaign %}
+                        {% trans "Edit campaign" %}
+                    {% else %}
+                        {% trans "Create campaign" %}
+                    {% endif %}
+                </h2>
+                {% if current_campaign %}
+                    <span class="status-chip">ID {{ current_campaign.pk }}</span>
+                {% endif %}
+            </header>
+            <form method="post" class="form-grid">
+                {% csrf_token %}
+                {{ campaign_form.non_field_errors }}
+                {{ campaign_form.auto_schedule }}
+                {% if current_campaign %}
+                    <input type="hidden" name="campaign_id" value="{{ current_campaign.pk }}">
+                {% endif %}
+                <div class="form-field">
+                    <label for="{{ campaign_form.name.id_for_label }}">{% trans "Name" %}</label>
+                    {{ campaign_form.name.as_widget(attrs={'class': 'input', 'placeholder': _('Product launch update')}) }}
+                    {{ campaign_form.name.errors }}
+                </div>
+                <div class="form-field">
+                    <label for="{{ campaign_form.email_template.id_for_label }}">{% trans "Email template" %}</label>
+                    {{ campaign_form.email_template.as_widget(attrs={'class': 'input'}) }}
+                    {{ campaign_form.email_template.errors }}
+                </div>
+                <div class="form-field">
+                    <label>{% trans "Subscription lists" %}</label>
+                    {{ campaign_form.lists }}
+                    {{ campaign_form.lists.errors }}
+                    <p class="help-text">{% trans "Choose at least one list to deliver this campaign." %}</p>
+                </div>
+                <div class="form-grid two-column">
+                    <div class="form-field">
+                        <label for="{{ campaign_form.send_at.id_for_label }}">{% trans "Send at" %}</label>
+                        {{ campaign_form.send_at.as_widget(attrs={'class': 'input'}) }}
+                        {{ campaign_form.send_at.errors }}
+                    </div>
+                    <div class="form-field">
+                        <label for="{{ campaign_form.send_timezone.id_for_label }}">{% trans "Timezone" %}</label>
+                        {{ campaign_form.send_timezone.as_widget(attrs={'class': 'input', 'placeholder': 'UTC'}) }}
+                        {{ campaign_form.send_timezone.errors }}
+                    </div>
+                </div>
+                <div class="form-field">
+                    <label for="{{ campaign_form.notes.id_for_label }}">{% trans "Notes" %}</label>
+                    {{ campaign_form.notes.as_widget(attrs={'class': 'input', 'rows': 4}) }}
+                    {{ campaign_form.notes.errors }}
+                </div>
+                <div class="form-field" style="display: none;">
+                    {{ campaign_form.archived }}
+                </div>
+                <div style="display:flex; gap:0.75rem;">
+                    <button type="submit" class="button button-primary">
+                        {% if current_campaign %}{% trans "Update campaign" %}{% else %}{% trans "Create campaign" %}{% endif %}
+                    </button>
+                    {% if current_campaign %}
+                        <a href="{{ request.path }}" class="button button-muted">{% trans "Clear" %}</a>
+                    {% endif %}
+                </div>
+            </form>
+        </section>
+
+        <section class="panel">
+            <header>
+                <h2>{% trans "All campaigns" %}</h2>
+                <span class="muted">{% blocktrans %}{{ campaigns_page.paginator.count }} total{% endblocktrans %}</span>
+            </header>
+            {% if campaigns_page %}
+                <table class="campaign-table">
+                    <thead>
+                        <tr>
+                            <th>{% trans "Name" %}</th>
+                            <th>{% trans "Lists" %}</th>
+                            <th>{% trans "Status" %}</th>
+                            <th>{% trans "Scheduled" %}</th>
+                            <th>{% trans "Actions" %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for campaign in campaigns_page %}
+                            <tr>
+                                <td>
+                                    <strong>{{ campaign.name }}</strong><br>
+                                    <small class="muted">{% trans "Template" %}: {{ campaign.email_template.name }}</small>
+                                </td>
+                                <td>
+                                    <div class="tags">
+                                        {% for lst in campaign.lists.all %}
+                                            <span class="tag">{{ lst.name }}</span>
+                                        {% empty %}
+                                            <span class="muted">{% trans "No lists" %}</span>
+                                        {% endfor %}
+                                    </div>
+                                </td>
+                                <td>
+                                    {{ campaign.get_status_display }}
+                                    {% if campaign.archived %}<br><small class="muted">{% trans "Archived" %}</small>{% endif %}
+                                </td>
+                                <td>
+                                    {% if campaign.send_at %}
+                                        {{ campaign.send_at|date:"M d, Y H:i" }}{% if campaign.send_timezone %} {{ campaign.send_timezone }}{% endif %}
+                                    {% else %}
+                                        <span class="muted">{% trans "Send immediately" %}</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <div class="table-actions">
+                                        <a class="button button-secondary button-small" href="?campaign={{ campaign.pk }}">{% trans "Edit" %}</a>
+                                        <form method="post" action="{{ request.path }}">
+                                            {% csrf_token %}
+                                            <input type="hidden" name="campaign_id" value="{{ campaign.pk }}">
+                                            {% if campaign.archived %}
+                                                <button class="button button-muted button-small" name="action" value="restore">{% trans "Restore" %}</button>
+                                            {% else %}
+                                                <button class="button button-muted button-small" name="action" value="archive">{% trans "Archive" %}</button>
+                                            {% endif %}
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <div class="pagination">
+                    {% if campaigns_page.has_previous %}
+                        <a href="?page={{ campaigns_page.previous_page_number }}">{% trans "Previous" %}</a>
+                    {% endif %}
+                    <span class="muted">{% blocktrans %}Page {{ campaigns_page.number }} of {{ campaigns_page.paginator.num_pages }}{% endblocktrans %}</span>
+                    {% if campaigns_page.has_next %}
+                        <a href="?page={{ campaigns_page.next_page_number }}">{% trans "Next" %}</a>
+                    {% endif %}
+                </div>
+            {% else %}
+                <div class="empty-state">{% trans "No campaigns yet. Create your first campaign using the form." %}</div>
+            {% endif %}
+        </section>
+    </div>
+</div>
+{% endblock %}

--- a/newsletter/templates/newsletter/admin/dashboard.html
+++ b/newsletter/templates/newsletter/admin/dashboard.html
@@ -1,331 +1,304 @@
-{% extends "wagtailadmin/base.html" %}
+{% extends "newsletter/admin/base.html" %}
 {% load i18n %}
 
-{% block extra_css %}
-<link href="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.css" rel="stylesheet">
+{% block title %}{{ page_title }} · Aquiles Newsletter{% endblock %}
+
+{% block extra_head %}
 <style>
-    .stats-grid {
+    .stat-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-        gap: 1rem;
-        margin-bottom: 2rem;
+        gap: 1.2rem;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     }
-    .dashboard-actions {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        flex-wrap: wrap;
-        gap: 1rem;
-        margin-bottom: 1.5rem;
-    }
-    .dashboard-actions a.button-primary {
-        background: linear-gradient(135deg, #6366f1, #4f46e5);
-        color: #fff;
-        padding: 0.6rem 1.2rem;
-        border-radius: 999px;
-        font-weight: 600;
-        text-decoration: none;
-        display: inline-flex;
-        align-items: center;
-        gap: 0.4rem;
-        box-shadow: 0 12px 24px -18px rgba(79, 70, 229, 0.7);
-    }
+
     .stat-card {
-        background: white;
-        border: 1px solid #e1e5e9;
-        border-radius: 8px;
-        padding: 1.5rem;
-        text-align: center;
+        background: linear-gradient(160deg, rgba(99,102,241,0.12), rgba(14,165,233,0.12));
+        border-radius: 18px;
+        padding: 1.4rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        border: 1px solid rgba(99, 102, 241, 0.15);
     }
-    .stat-number {
-        font-size: 2rem;
-        font-weight: bold;
-        color: #2c3e50;
-        margin-bottom: 0.5rem;
-    }
-    .stat-label {
-        color: #7f8c8d;
+
+    .stat-card h3 {
+        margin: 0;
         font-size: 0.9rem;
         text-transform: uppercase;
-        letter-spacing: 0.5px;
+        letter-spacing: 0.08em;
+        color: rgba(15, 23, 42, 0.65);
     }
-    .chart-container {
-        background: white;
-        border: 1px solid #e1e5e9;
-        border-radius: 8px;
+
+    .stat-card strong {
+        font-size: 1.9rem;
+        font-weight: 700;
+        color: #0f172a;
+    }
+
+    .detail-grid {
+        display: grid;
+        gap: 2rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        margin-top: 2rem;
+    }
+
+    .panel {
+        border-radius: 18px;
+        border: 1px solid rgba(148, 163, 184, 0.2);
         padding: 1.5rem;
-        margin-bottom: 1rem;
+        background: rgba(255, 255, 255, 0.9);
+        box-shadow: 0 20px 45px -25px rgba(15, 23, 42, 0.18);
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
     }
-    .timeline-list {
-        list-style: none;
-        padding-left: 0;
-        margin: 0;
-    }
-    .timeline-list li {
-        position: relative;
-        padding-left: 1.5rem;
-        margin-bottom: 1rem;
-        border-left: 2px solid rgba(79, 70, 229, 0.2);
-    }
-    .timeline-list li::before {
-        content: "";
-        position: absolute;
-        left: -6px;
-        top: 8px;
-        width: 10px;
-        height: 10px;
-        border-radius: 50%;
-        background: #4f46e5;
-        box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15);
-    }
-    .recent-activity {
-        max-height: 400px;
-        overflow-y: auto;
-    }
-    .activity-item {
-        padding: 0.75rem;
-        border-bottom: 1px solid #f1f3f4;
+
+    .panel header {
         display: flex;
         justify-content: space-between;
-        align-items: center;
+        align-items: flex-end;
     }
-    .activity-item:last-child {
-        border-bottom: none;
+
+    .panel header h3 {
+        margin: 0;
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: #0f172a;
     }
-    .status-badge {
-        padding: 0.25rem 0.5rem;
-        border-radius: 4px;
-        font-size: 0.75rem;
-        font-weight: bold;
-        text-transform: uppercase;
-    }
-    .status-draft { background: #f39c12; color: white; }
-    .status-scheduled { background: #3498db; color: white; }
-    .status-sending { background: #e74c3c; color: white; }
-    .status-sent { background: #27ae60; color: white; }
-    .status-cancelled { background: #95a5a6; color: white; }
-    .drip-overview {
+
+    .timeline {
         display: grid;
         gap: 1rem;
-        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        max-height: 360px;
+        overflow-y: auto;
+        padding-right: 0.25rem;
     }
-    .drip-card {
-        border: 1px solid #eef0f4;
-        border-radius: 8px;
-        padding: 1rem;
-        background: #f9fafb;
+
+    .timeline-item {
+        padding-left: 1.2rem;
+        position: relative;
     }
-    .drip-card h4 {
-        margin: 0 0 0.5rem 0;
+
+    .timeline-item::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.4rem;
+        width: 0.55rem;
+        height: 0.55rem;
+        background: var(--primary);
+        border-radius: 50%;
+        box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.18);
     }
-    .drip-card ul {
+
+    .timeline-item strong {
+        display: block;
+        margin-bottom: 0.25rem;
+        color: #0f172a;
+    }
+
+    .timeline-item small {
+        color: var(--text-muted);
+    }
+
+    .drip-steps {
+        list-style: none;
         margin: 0;
-        padding-left: 1.1rem;
-        color: #4b5563;
+        padding: 0;
+        display: grid;
+        gap: 0.35rem;
+        font-size: 0.9rem;
+        color: var(--text-muted);
     }
-    .drip-card li {
-        margin-bottom: 0.35rem;
+
+    .chart-wrapper {
+        position: relative;
+        height: 320px;
+    }
+
+    canvas {
+        width: 100% !important;
+        height: 100% !important;
     }
 </style>
 {% endblock %}
 
 {% block content %}
-<div class="nice-padding">
-    <div class="dashboard-actions">
-        <h1 class="wagtail-admin-title" style="margin: 0;">{% trans "Newsletter Dashboard" %}</h1>
-        <a href="{% url 'newsletter_workspace' %}" class="button-primary">
-            {% trans "Open modern workspace" %}
-        </a>
-    </div>
-    
-    <!-- Stats Grid -->
-    <div class="stats-grid">
-        <div class="stat-card">
-            <div class="stat-number">{{ active_subscriptions }}</div>
-            <div class="stat-label">{% trans "Active Subscribers" %}</div>
-        </div>
-        <div class="stat-card">
-            <div class="stat-number">{{ total_emails_sent }}</div>
-            <div class="stat-label">{% trans "Emails Sent" %}</div>
-        </div>
-        <div class="stat-card">
-            <div class="stat-number">{{ open_rate }}%</div>
-            <div class="stat-label">{% trans "Open Rate" %}</div>
-        </div>
-        <div class="stat-card">
-            <div class="stat-number">{{ click_rate }}%</div>
-            <div class="stat-label">{% trans "Click Rate" %}</div>
-        </div>
-        <div class="stat-card">
-            <div class="stat-number">{{ total_campaigns }}</div>
-            <div class="stat-label">{% trans "Total Campaigns" %}</div>
-        </div>
-        <div class="stat-card">
-            <div class="stat-number">{{ new_subscriptions_30d }}</div>
-            <div class="stat-label">{% trans "New This Month" %}</div>
-        </div>
-    </div>
-
-    <div style="display: grid; grid-template-columns: 2fr 1fr; gap: 2rem;">
-        <!-- Left Column -->
+<div class="page-section">
+    <div class="section-header">
         <div>
-            <!-- Email Performance -->
-            <div class="chart-container">
-                <h3>{% trans "Email Performance" %}</h3>
-                <canvas id="performanceChart" width="400" height="200"></canvas>
-            </div>
+            <p class="muted">{% trans "Track the health of your newsletter at a glance." %}</p>
+        </div>
+        <div class="pill">{% blocktrans count total=lists|length %}{{ total }} list active{% plural %}{{ total }} lists active{% endblocktrans %}</div>
+    </div>
 
-            <!-- Recent Campaigns -->
-            <div class="chart-container">
-                <h3>{% trans "Recent Campaigns" %}</h3>
-                {% if recent_campaigns %}
-                    <div class="recent-activity">
-                        {% for campaign in recent_campaigns %}
-                        <div class="activity-item">
-                            <div>
-                                <strong>{{ campaign.name }}</strong><br>
-                                <small class="text-muted">{{ campaign.email_template.name }}</small>
-                            </div>
-                            <div>
-                                <span class="status-badge status-{{ campaign.status }}">{{ campaign.get_status_display }}</span><br>
-                                <small class="text-muted">{{ campaign.created_at|date:"M d, Y" }}</small>
-                            </div>
+    <div class="stat-grid">
+        <div class="stat-card">
+            <h3>{% trans "Active subscribers" %}</h3>
+            <strong>{{ active_subscriptions }}</strong>
+            <small class="muted">{% blocktrans %}{{ total_subscriptions }} total{% endblocktrans %}</small>
+        </div>
+        <div class="stat-card">
+            <h3>{% trans "New in 30 days" %}</h3>
+            <strong>{{ new_subscriptions_30d }}</strong>
+            <small class="muted">{% trans "Fresh subscribers recently" %}</small>
+        </div>
+        <div class="stat-card">
+            <h3>{% trans "Campaigns" %}</h3>
+            <strong>{{ campaigns_total }}</strong>
+            <small class="muted">{% trans "Across all lists" %}</small>
+        </div>
+        <div class="stat-card">
+            <h3>{% trans "Emails sent" %}</h3>
+            <strong>{{ total_emails_sent }}</strong>
+            <small class="muted">{% trans "Lifetime deliveries" %}</small>
+        </div>
+        <div class="stat-card">
+            <h3>{% trans "Opens" %}</h3>
+            <strong>{{ open_rate }}%</strong>
+            <small class="muted">{% trans "Average open rate" %}</small>
+        </div>
+        <div class="stat-card">
+            <h3>{% trans "Clicks" %}</h3>
+            <strong>{{ click_rate }}%</strong>
+            <small class="muted">{% trans "Engagement" %}</small>
+        </div>
+    </div>
+
+    <div class="detail-grid">
+        <section class="panel">
+            <header>
+                <h3>{% trans "Performance" %}</h3>
+                <span class="muted">{% trans "Deliveries vs. engagement" %}</span>
+            </header>
+            <div class="chart-wrapper">
+                <canvas id="performanceChart"></canvas>
+            </div>
+        </section>
+
+        <section class="panel">
+            <header>
+                <h3>{% trans "Recent campaigns" %}</h3>
+                <span class="muted">{% trans "Latest activity" %}</span>
+            </header>
+            {% if recent_campaigns %}
+                <div class="timeline">
+                    {% for campaign in recent_campaigns %}
+                        <div class="timeline-item">
+                            <strong>{{ campaign.name }}</strong>
+                            <small>
+                                {{ campaign.get_status_display }} ·
+                                {{ campaign.created_at|date:"M d, Y" }}
+                                {% if campaign.email_template %}· {{ campaign.email_template.name }}{% endif %}
+                            </small>
                         </div>
-                        {% endfor %}
-                    </div>
-                {% else %}
-                    <p class="text-muted">{% trans "No campaigns yet." %}</p>
-                {% endif %}
-            </div>
-        </div>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <div class="empty-state">{% trans "No campaigns have been created yet." %}</div>
+            {% endif %}
+        </section>
+    </div>
 
-        <!-- Right Column -->
-        <div>
-            <div class="chart-container">
+    <div class="detail-grid">
+        <section class="panel">
+            <header>
                 <h3>{% trans "Upcoming sends" %}</h3>
-                {% if upcoming_campaigns %}
-                <ul class="timeline-list">
+                <span class="muted">{% trans "Scheduled newsletters" %}</span>
+            </header>
+            {% if upcoming_campaigns %}
+                <div class="timeline">
                     {% for campaign in upcoming_campaigns %}
-                    <li>
-                        <strong>{{ campaign.name }}</strong><br>
-                        <small class="text-muted">{{ campaign.send_at|date:"M d, Y H:i" }} · {{ campaign.email_template.name }}</small>
-                    </li>
-                    {% endfor %}
-                </ul>
-                {% else %}
-                <p class="text-muted">{% trans "No scheduled sends." %}</p>
-                {% endif %}
-            </div>
-            <!-- Subscription Lists -->
-            <div class="chart-container">
-                <h3>{% trans "Subscription Lists" %}</h3>
-                {% if lists %}
-                    {% for list in lists %}
-                    <div class="activity-item">
-                        <div>
-                            <strong>{{ list.name }}</strong><br>
-                            <small class="text-muted">{{ list.description|truncatechars:50 }}</small>
+                        <div class="timeline-item">
+                            <strong>{{ campaign.name }}</strong>
+                            <small>
+                                {{ campaign.send_at|date:"M d, Y H:i" }}
+                                {% if campaign.send_timezone %}{{ campaign.send_timezone }}{% endif %}
+                            </small>
                         </div>
-                        <div style="text-align: right;">
-                            <div class="stat-number" style="font-size: 1.2rem; margin-bottom: 0;">{{ list.subscriptions.count }}</div>
-                            <small class="text-muted">{% trans "subscribers" %}</small>
-                        </div>
-                    </div>
                     {% endfor %}
-                {% else %}
-                    <p class="text-muted">{% trans "No subscription lists yet." %}</p>
-                {% endif %}
-            </div>
+                </div>
+            {% else %}
+                <div class="empty-state">{% trans "You do not have campaigns scheduled." %}</div>
+            {% endif %}
+        </section>
 
-            <!-- Recent Email Activity -->
-            <div class="chart-container">
-                <h3>{% trans "Recent Email Activity" %}</h3>
-                {% if recent_emails %}
-                    <div class="recent-activity">
-                        {% for email in recent_emails %}
-                        <div class="activity-item">
-                            <div>
-                                <strong>{{ email.subject|truncatechars:30 }}</strong><br>
-                                <small class="text-muted">{{ email.subscriber.email }}</small>
-                            </div>
-                            <div>
-                                <span class="status-badge status-{{ email.status }}">{{ email.get_status_display }}</span><br>
-                                <small class="text-muted">{{ email.sent_at|date:"M d" }}</small>
-                            </div>
+        <section class="panel">
+            <header>
+                <h3>{% trans "Latest deliveries" %}</h3>
+                <span class="muted">{% trans "Recent individual emails" %}</span>
+            </header>
+            {% if recent_emails %}
+                <div class="timeline">
+                    {% for log in recent_emails %}
+                        <div class="timeline-item">
+                            <strong>{{ log.subject }}</strong>
+                            <small>{{ log.subscriber.email }} · {{ log.sent_at|date:"M d, Y H:i" }}</small>
                         </div>
-                        {% endfor %}
-                    </div>
-                {% else %}
-                    <p class="text-muted">{% trans "No recent email activity." %}</p>
-                {% endif %}
-            </div>
-        </div>
-    </div>
-
-    <div class="chart-container">
-        <h3>{% trans "Drip sequences" %}</h3>
-        {% if drip_overview %}
-        <div class="drip-overview">
-            {% for drip in drip_overview %}
-            <div class="drip-card">
-                <h4>{{ drip.name }}</h4>
-                <p class="text-muted" style="margin-bottom: 0.5rem;">{{ drip.list }} · {% if drip.enabled %}{% trans "Enabled" %}{% else %}{% trans "Disabled" %}{% endif %}</p>
-                {% if drip.steps %}
-                <ul>
-                    {% for step in drip.steps %}
-                    <li>
-                        <strong>{{ step.order }}.</strong>
-                        {{ step.title }}
-                        <span class="text-muted">
-                            ({{ step.offset_weeks }}w {{ step.offset_days }}d)
-                        </span>
-                    </li>
                     {% endfor %}
-                </ul>
-                {% else %}
-                <p class="text-muted">{% trans "No steps configured." %}</p>
-                {% endif %}
-            </div>
-            {% endfor %}
-        </div>
-        {% else %}
-        <p class="text-muted">{% trans "No drip campaigns defined yet." %}</p>
-        {% endif %}
+                </div>
+            {% else %}
+                <div class="empty-state">{% trans "No recent emails sent." %}</div>
+            {% endif %}
+        </section>
+
+        <section class="panel">
+            <header>
+                <h3>{% trans "Drip campaigns" %}</h3>
+                <span class="muted">{% trans "Sequences in flight" %}</span>
+            </header>
+            {% if drips %}
+                <div class="timeline">
+                    {% for drip in drips %}
+                        <div class="timeline-item">
+                            <strong>{{ drip.name }}</strong>
+                            <small>{{ drip.subscription_list.name }} · {% if drip.enabled %}{% trans "Enabled" %}{% else %}{% trans "Paused" %}{% endif %}</small>
+                            <ul class="drip-steps">
+                                {% for step in drip.steps.all %}
+                                    <li>#{{ step.order }} · {{ step.title }} ({{ step.offset_days }} {% trans "days" %})</li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <div class="empty-state">{% trans "No drip campaigns configured." %}</div>
+            {% endif %}
+        </section>
     </div>
 </div>
+
+{{ performance_chart|json_script:"performance-data" }}
 {% endblock %}
 
 {% block extra_js %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-    // Email Performance Chart
+    const performanceData = JSON.parse(document.getElementById('performance-data').textContent);
     const ctx = document.getElementById('performanceChart').getContext('2d');
-    new Chart(ctx, {
+    new window.Chart(ctx, {
         type: 'doughnut',
         data: {
-            labels: ['{% trans "Delivered" %}', '{% trans "Opened" %}', '{% trans "Clicked" %}', '{% trans "Bounced" %}'],
+            labels: performanceData.labels,
             datasets: [{
-                data: [{{ emails_delivered }}, {{ emails_opened }}, {{ emails_clicked }}, {{ emails_bounced }}],
-                backgroundColor: [
-                    '#27ae60',
-                    '#3498db', 
-                    '#f39c12',
-                    '#e74c3c'
-                ],
-                borderWidth: 0
-            }]
+                data: performanceData.values,
+                backgroundColor: ['#6366f1', '#22d3ee', '#0ea5e9', '#f97316'],
+                borderWidth: 0,
+            }],
         },
         options: {
-            responsive: true,
-            maintainAspectRatio: false,
             plugins: {
                 legend: {
-                    position: 'bottom'
-                }
-            }
-        }
+                    position: 'bottom',
+                    labels: {
+                        boxWidth: 12,
+                        boxHeight: 12,
+                        color: '#334155',
+                        font: { family: 'Inter', size: 12 },
+                    },
+                },
+            },
+        },
     });
-});
 </script>
 {% endblock %}

--- a/newsletter/templates/newsletter/admin/drips.html
+++ b/newsletter/templates/newsletter/admin/drips.html
@@ -1,0 +1,147 @@
+{% extends "newsletter/admin/base.html" %}
+{% load i18n %}
+
+{% block title %}{{ page_title }} · Aquiles Newsletter{% endblock %}
+
+{% block extra_head %}
+<style>
+    .drip-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }
+
+    .drip-card {
+        padding: 1.5rem;
+        border-radius: 18px;
+        background: rgba(255,255,255,0.95);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        box-shadow: 0 18px 45px -28px rgba(15, 23, 42, 0.2);
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+
+    .drip-card header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .drip-card h3 {
+        margin: 0;
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: #0f172a;
+    }
+
+    .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+        font-size: 0.82rem;
+        color: var(--text-muted);
+    }
+
+    .badge {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.25rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        background: rgba(99, 102, 241, 0.15);
+        color: #3730a3;
+    }
+
+    .badge-success {
+        background: rgba(22, 163, 74, 0.12);
+        color: #166534;
+    }
+
+    .badge-muted {
+        background: rgba(148, 163, 184, 0.18);
+        color: #334155;
+    }
+
+    .steps {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.45rem;
+        font-size: 0.9rem;
+    }
+
+    .steps li {
+        padding: 0.45rem 0.65rem;
+        border-radius: 12px;
+        background: rgba(15, 23, 42, 0.04);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    .steps small {
+        color: var(--text-muted);
+        font-size: 0.8rem;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="page-section">
+    <div class="section-header">
+        <div>
+            <p class="muted">{% trans "Automate onboarding and nurture journeys with drip sequences." %}</p>
+        </div>
+        <div class="pill">
+            {% blocktrans %}{{ active_drip_count }} active · {{ archived_drip_count }} archived{% endblocktrans %}
+        </div>
+    </div>
+
+    {% if drips %}
+        <div class="drip-grid">
+            {% for drip in drips %}
+                <article class="drip-card">
+                    <header>
+                        <h3>{{ drip.name }}</h3>
+                        <span class="badge {% if drip.enabled and not drip.archived %}badge-success{% else %}badge-muted{% endif %}">
+                            {% if drip.archived %}{% trans "Archived" %}{% elif drip.enabled %}{% trans "Active" %}{% else %}{% trans "Paused" %}{% endif %}
+                        </span>
+                    </header>
+                    <div class="meta">
+                        <span>{% trans "List" %}: {{ drip.subscription_list.name }}</span>
+                        <span>•</span>
+                        <span>{% trans "Start" %}: {{ drip.get_start_strategy_display }}</span>
+                        {% if drip.start_delay_days %}
+                            <span>•</span>
+                            <span>{% trans "Delay" %}: {{ drip.start_delay_days }} {% trans "days" %}</span>
+                        {% endif %}
+                        <span>•</span>
+                        <span>{% trans "Send" %}: {{ drip.send_time|time:"H:i" }} {{ drip.timezone }}</span>
+                    </div>
+                    <p class="muted">{{ drip.description }}</p>
+                    <ul class="steps">
+                        {% for step in drip.steps.all %}
+                            <li>
+                                <span>#{{ step.order }} · {{ step.title }}</span>
+                                <small>
+                                    {% trans "Offset" %}: {{ step.offset_days }} {% trans "days" %}
+                                    {% if step.offset_weeks %}+ {{ step.offset_weeks }} {% trans "weeks" %}{% endif %}
+                                </small>
+                            </li>
+                        {% empty %}
+                            <li><span>{% trans "No steps yet." %}</span></li>
+                        {% endfor %}
+                    </ul>
+                </article>
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="empty-state">{% trans "No drip campaigns found." %}</div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/newsletter/templates/newsletter/admin/editor.html
+++ b/newsletter/templates/newsletter/admin/editor.html
@@ -1,0 +1,240 @@
+{% extends "newsletter/admin/base.html" %}
+{% load i18n %}
+
+{% block title %}{{ page_title }} · Aquiles Newsletter{% endblock %}
+
+{% block extra_head %}
+<link rel="stylesheet" href="https://unpkg.com/trix@2.1.6/dist/trix.css">
+<style>
+    .editor-layout {
+        display: grid;
+        grid-template-columns: minmax(240px, 280px) 1fr;
+        gap: 2rem;
+    }
+
+    @media (max-width: 980px) {
+        .editor-layout {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    .template-list {
+        background: rgba(255,255,255,0.95);
+        border-radius: 18px;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        padding: 1.5rem;
+        box-shadow: 0 18px 40px -30px rgba(15, 23, 42, 0.2);
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .template-list h2 {
+        margin: 0;
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: #0f172a;
+    }
+
+    .template-items {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+    }
+
+    .template-items a {
+        display: block;
+        padding: 0.55rem 0.75rem;
+        border-radius: 12px;
+        text-decoration: none;
+        font-weight: 500;
+        color: var(--text);
+        transition: background 0.2s ease, transform 0.2s ease;
+    }
+
+    .template-items a:hover {
+        background: rgba(99, 102, 241, 0.08);
+        transform: translateX(2px);
+    }
+
+    .template-items a.active {
+        background: rgba(99, 102, 241, 0.16);
+        color: #312e81;
+        box-shadow: inset 0 0 0 1px rgba(99, 102, 241, 0.2);
+    }
+
+    .editor-panel {
+        background: rgba(255,255,255,0.95);
+        border-radius: 18px;
+        padding: 1.8rem;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+        box-shadow: 0 25px 50px -28px rgba(15, 23, 42, 0.2);
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    trix-editor {
+        min-height: 320px;
+        border-radius: 12px;
+        border: 1px solid rgba(148, 163, 184, 0.4);
+        padding: 0.85rem;
+        font-family: inherit;
+    }
+
+    trix-toolbar {
+        border-radius: 12px 12px 0 0;
+    }
+
+    .preview-box {
+        display: grid;
+        gap: 0.6rem;
+    }
+
+    .preview-box textarea {
+        min-height: 140px;
+        resize: vertical;
+    }
+
+    .plain-text-error {
+        background: rgba(220, 38, 38, 0.12);
+        border-radius: 12px;
+        padding: 0.75rem;
+        color: #b91c1c;
+        font-size: 0.9rem;
+    }
+
+    .template-meta {
+        display: grid;
+        gap: 1rem;
+    }
+
+    .inline-checkbox {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+        font-size: 0.9rem;
+        font-weight: 500;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="page-section">
+    <div class="section-header">
+        <div>
+            <p class="muted">{% trans "Craft campaigns with a friendly editor and export clean plain-text copies." %}</p>
+        </div>
+        <div class="pill">
+            {% blocktrans %}{{ templates|length }} templates available{% endblocktrans %}
+        </div>
+    </div>
+
+    <div class="editor-layout">
+        <aside class="template-list">
+            <h2>{% trans "Templates" %}</h2>
+            <a class="button button-secondary" href="{{ request.path }}">{% trans "Create new" %}</a>
+            <ul class="template-items">
+                {% for template in templates %}
+                    <li>
+                        <a href="?template={{ template.pk }}" class="{% if current_template and current_template.pk == template.pk %}active{% endif %}">
+                            {{ template.name }}
+                            {% if template.archived %}<br><small class="muted">{% trans "Archived" %}</small>{% endif %}
+                        </a>
+                    </li>
+                {% empty %}
+                    <li class="muted">{% trans "No templates yet." %}</li>
+                {% endfor %}
+            </ul>
+        </aside>
+
+        <section class="editor-panel">
+            <form method="post" class="template-meta">
+                {% csrf_token %}
+                {{ template_form.non_field_errors }}
+                {% if current_template %}
+                    <input type="hidden" name="template_id" value="{{ current_template.pk }}">
+                {% endif %}
+                <div class="form-grid two-column">
+                    <div class="form-field">
+                        <label for="{{ template_form.name.id_for_label }}">{% trans "Template name" %}</label>
+                        {{ template_form.name.as_widget(attrs={'class': 'input', 'placeholder': _('Weekly digest')}) }}
+                        {{ template_form.name.errors }}
+                    </div>
+                    <div class="form-field">
+                        <label for="{{ template_form.preview_text.id_for_label }}">{% trans "Preview text" %}</label>
+                        {{ template_form.preview_text.as_widget(attrs={'class': 'input', 'placeholder': _('Appears in inbox previews')}) }}
+                        {{ template_form.preview_text.errors }}
+                    </div>
+                </div>
+                <div class="form-field">
+                    <label for="{{ template_form.subject_template.id_for_label }}">{% trans "Subject" %}</label>
+                    {{ template_form.subject_template.as_widget(attrs={'class': 'input'}) }}
+                    {{ template_form.subject_template.errors }}
+                </div>
+                {{ template_form.html_body }}
+                <div class="form-field">
+                    <label>{% trans "Content" %}</label>
+                    <trix-editor input="{{ template_form.html_body.id_for_label }}"></trix-editor>
+                </div>
+                <div class="form-field">
+                    <label for="{{ template_form.text_body.id_for_label }}">{% trans "Plain text override" %}</label>
+                    {{ template_form.text_body.as_widget(attrs={'class': 'input', 'rows': 4, 'placeholder': _('Leave blank to auto-generate from HTML')}) }}
+                    {{ template_form.text_body.errors }}
+                </div>
+                <label class="inline-checkbox">
+                    {{ template_form.archived }} {% trans "Mark as archived" %}
+                </label>
+                <div style="display:flex; gap:0.75rem;">
+                    <button type="submit" class="button button-primary">{% trans "Save template" %}</button>
+                    {% if current_template %}
+                        <a href="{{ request.path }}" class="button button-muted">{% trans "Reset" %}</a>
+                    {% endif %}
+                </div>
+            </form>
+
+            <div class="preview-box">
+                <h3 style="margin:0; font-size:1.05rem;">{% trans "Plain text preview" %}</h3>
+                {% if plain_text_error %}
+                    <div class="plain-text-error">{{ plain_text_error }}</div>
+                {% endif %}
+                <textarea id="plain-text-output" class="input" readonly>{{ plain_text_preview }}</textarea>
+                <button type="button" class="button button-secondary" id="copy-plain-text">{% trans "Copy plain text" %}</button>
+            </div>
+        </section>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_js %}
+<script src="https://unpkg.com/trix@2.1.6/dist/trix.umd.min.js"></script>
+<script>
+    const editorInputId = '{{ template_form.html_body.id_for_label }}';
+    document.addEventListener('DOMContentLoaded', function () {
+        const hiddenInput = document.getElementById(editorInputId);
+        const trixEditor = document.querySelector(`trix-editor[input="${editorInputId}"]`);
+        if (hiddenInput && trixEditor) {
+            trixEditor.value = hiddenInput.value;
+            trixEditor.addEventListener('trix-change', function () {
+                hiddenInput.value = trixEditor.value;
+            });
+        }
+        const copyButton = document.getElementById('copy-plain-text');
+        const plainTextArea = document.getElementById('plain-text-output');
+        if (copyButton && plainTextArea) {
+            copyButton.addEventListener('click', async function () {
+                try {
+                    await navigator.clipboard.writeText(plainTextArea.value);
+                    copyButton.textContent = '{% trans "Copied!" %}';
+                    setTimeout(() => { copyButton.textContent = '{% trans "Copy plain text" %}'; }, 1800);
+                } catch (error) {
+                    copyButton.textContent = '{% trans "Unable to copy" %}';
+                }
+            });
+        }
+    });
+</script>
+{% endblock %}

--- a/newsletter/templates/newsletter/admin/subscribers.html
+++ b/newsletter/templates/newsletter/admin/subscribers.html
@@ -1,0 +1,182 @@
+{% extends "newsletter/admin/base.html" %}
+{% load i18n %}
+
+{% block title %}{{ page_title }} · Aquiles Newsletter{% endblock %}
+
+{% block extra_head %}
+<style>
+    .filters {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+        margin-top: 1.5rem;
+        align-items: end;
+    }
+
+    .status-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+        margin-bottom: 1.5rem;
+    }
+
+    .status-pill {
+        background: rgba(15, 23, 42, 0.06);
+        border-radius: 999px;
+        padding: 0.35rem 0.7rem;
+        font-size: 0.78rem;
+        font-weight: 600;
+    }
+
+    .status-pill strong {
+        margin-left: 0.35rem;
+        color: #0f172a;
+    }
+
+    .subscription-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+    }
+
+    .subscription-tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.25rem 0.55rem;
+        border-radius: 999px;
+        background: rgba(99, 102, 241, 0.08);
+        font-size: 0.78rem;
+        font-weight: 500;
+    }
+
+    .subscription-tag[data-status="active"] {
+        background: rgba(22, 163, 74, 0.12);
+        color: #166534;
+    }
+
+    .subscription-tag[data-status="pending"] {
+        background: rgba(245, 158, 11, 0.15);
+        color: #b45309;
+    }
+
+    .subscription-tag[data-status="unsubscribed"] {
+        background: rgba(239, 68, 68, 0.12);
+        color: #b91c1c;
+    }
+
+    .subscription-tag[data-status="bounced"] {
+        background: rgba(148, 163, 184, 0.18);
+        color: #334155;
+    }
+
+    .pagination {
+        margin-top: 1.25rem;
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.75rem;
+        align-items: center;
+        font-size: 0.9rem;
+    }
+
+    .pagination a {
+        color: var(--primary);
+        font-weight: 600;
+        text-decoration: none;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="page-section">
+    <div class="section-header">
+        <div>
+            <p class="muted">{% trans "Review subscribers, segment by status and lists, and keep an eye on growth." %}</p>
+        </div>
+        <div class="pill">{% blocktrans %}{{ subscribers_page.paginator.count }} people total{% endblocktrans %}</div>
+    </div>
+
+    <form method="get" class="filters">
+        <div class="form-field">
+            <label for="subscriber-search">{% trans "Search" %}</label>
+            <input id="subscriber-search" type="search" name="q" value="{{ query }}" class="input" placeholder="you@example.com">
+        </div>
+        <div class="form-field">
+            <label for="subscriber-status">{% trans "Status" %}</label>
+            <select id="subscriber-status" name="status" class="input">
+                <option value="">{% trans "All statuses" %}</option>
+                {% for value, label in status_choices %}
+                    <option value="{{ value }}" {% if status_filter == value %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="form-field">
+            <label for="subscriber-list">{% trans "List" %}</label>
+            <select id="subscriber-list" name="list" class="input">
+                <option value="">{% trans "All lists" %}</option>
+                {% for lst in subscription_lists %}
+                    <option value="{{ lst.pk }}" {% if list_filter_value == lst.pk|stringformat:"s" %}selected{% endif %}>{{ lst.name }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div>
+            <button type="submit" class="button button-primary">{% trans "Apply" %}</button>
+        </div>
+    </form>
+
+    <div class="status-bar">
+        {% for item in status_summary %}
+            <span class="status-pill">{{ item.label }}<strong>{{ item.count }}</strong></span>
+        {% endfor %}
+    </div>
+
+    {% if subscribers_page %}
+        <table>
+            <thead>
+                <tr>
+                    <th>{% trans "Subscriber" %}</th>
+                    <th>{% trans "Lists" %}</th>
+                    <th>{% trans "Joined" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for subscriber in subscribers_page %}
+                    <tr>
+                        <td>
+                            <strong>{{ subscriber.email }}</strong><br>
+                            <small class="muted">{{ subscriber.first_name }} {{ subscriber.last_name }}</small>
+                        </td>
+                        <td>
+                            <div class="subscription-tags">
+                                {% for subscription in subscriber.subscriptions.all %}
+                                    <span class="subscription-tag" data-status="{{ subscription.status }}">
+                                        {{ subscription.subscription_list.name }}
+                                        <small>{{ subscription.get_status_display }}</small>
+                                    </span>
+                                {% empty %}
+                                    <span class="muted">{% trans "No list assigned" %}</span>
+                                {% endfor %}
+                            </div>
+                        </td>
+                        <td>
+                            {{ subscriber.created_at|date:"M d, Y" }}<br>
+                            <small class="muted">{% trans "Updated" %}: {{ subscriber.updated_at|date:"M d, Y" }}</small>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <div class="pagination">
+            {% if subscribers_page.has_previous %}
+                <a href="?{% if query %}q={{ query|urlencode }}&amp;{% endif %}{% if status_filter %}status={{ status_filter }}&amp;{% endif %}{% if list_filter %}list={{ list_filter }}&amp;{% endif %}page={{ subscribers_page.previous_page_number }}">{% trans "Previous" %}</a>
+            {% endif %}
+            <span class="muted">{% blocktrans %}Page {{ subscribers_page.number }} of {{ subscribers_page.paginator.num_pages }}{% endblocktrans %}</span>
+            {% if subscribers_page.has_next %}
+                <a href="?{% if query %}q={{ query|urlencode }}&amp;{% endif %}{% if status_filter %}status={{ status_filter }}&amp;{% endif %}{% if list_filter %}list={{ list_filter }}&amp;{% endif %}page={{ subscribers_page.next_page_number }}">{% trans "Next" %}</a>
+            {% endif %}
+        </div>
+    {% else %}
+        <div class="empty-state">{% trans "No subscribers match your filters." %}</div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/newsletter/urls.py
+++ b/newsletter/urls.py
@@ -8,6 +8,11 @@ from .webhooks import MailgunTrackingWebhookView
 app_name = "newsletter"
 
 urlpatterns = [
+    path("admin/", views.NewsletterDashboardView.as_view(), name="admin-dashboard"),
+    path("admin/campaigns/", views.CampaignListView.as_view(), name="admin-campaigns"),
+    path("admin/subscribers/", views.SubscriberListView.as_view(), name="admin-subscribers"),
+    path("admin/drip-campaigns/", views.DripCampaignListView.as_view(), name="admin-drips"),
+    path("admin/editor/", views.TemplateEditorView.as_view(), name="admin-editor"),
     path("subscribe/", views.SubscribeView.as_view(), name="subscribe"),
     path("confirm/<uuid:token>/", views.confirm_subscription, name="confirm"),
     path("unsubscribe/<uuid:token>/", views.unsubscribe, name="unsubscribe"),

--- a/newsletter/views.py
+++ b/newsletter/views.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from datetime import timedelta
 
 from django.conf import settings
+from types import SimpleNamespace
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.core.paginator import Paginator
+from django.db.models import Count, Q
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -11,8 +15,16 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 from django.views.generic import FormView, TemplateView
 
-from .forms import SubscriptionForm, UnsubscribeForm
-from .models import Subscriber, Subscription, SubscriptionList
+from .forms import CampaignForm, EmailTemplateForm, SubscriptionForm, UnsubscribeForm
+from .models import (
+    Campaign,
+    DripCampaign,
+    EmailMessageLog,
+    EmailTemplate,
+    Subscriber,
+    Subscription,
+    SubscriptionList,
+)
 from .tasks import process_drip_queue, send_confirmation
 
 
@@ -158,74 +170,343 @@ def unsubscribe(request: HttpRequest, token: str) -> HttpResponse:
     return render(request, "newsletter/public/unsubscribe.html", {"subscription": subscription, "form": form})
 
 
-class NewsletterDashboardView(TemplateView):
-    template_name = "newsletter/admin/dashboard.html"
+class NewsletterAdminMixin(LoginRequiredMixin, UserPassesTestMixin):
+    """Common behaviour for the standalone newsletter admin interface."""
+
+    section: str = ""
+    page_title: str = "Newsletter admin"
+
+    def test_func(self):
+        user = self.request.user
+        return user.is_active and user.is_staff
+
+    def get_page_title(self) -> str:
+        return self.page_title
+
+    def get_admin_navigation(self) -> list[dict[str, str]]:
+        return [
+            {"slug": "dashboard", "label": "Dashboard", "url": reverse("newsletter:admin-dashboard")},
+            {"slug": "campaigns", "label": "Campaigns", "url": reverse("newsletter:admin-campaigns")},
+            {"slug": "subscribers", "label": "Subscribers", "url": reverse("newsletter:admin-subscribers")},
+            {"slug": "drips", "label": "Drip campaigns", "url": reverse("newsletter:admin-drips")},
+            {"slug": "editor", "label": "Newsletter editor", "url": reverse("newsletter:admin-editor")},
+        ]
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        
-        # Basic counts
-        context["lists"] = SubscriptionList.objects.all()
-        context["subscriptions"] = Subscription.objects.select_related("subscription_list").count()
-        context["active_subscriptions"] = Subscription.objects.filter(status=Subscription.Status.ACTIVE).count()
-        context["pending_subscriptions"] = Subscription.objects.filter(status=Subscription.Status.PENDING).count()
-        
-        # Import Campaign and EmailMessageLog for analytics
-        from .models import Campaign, DripCampaign, EmailMessageLog, EmailEvent
-        
-        # Campaign analytics
-        active_campaigns = Campaign.objects.filter(archived=False)
-        context["total_campaigns"] = active_campaigns.count()
-        context["draft_campaigns"] = active_campaigns.filter(status=Campaign.Status.DRAFT).count()
-        context["scheduled_campaigns"] = active_campaigns.filter(status=Campaign.Status.SCHEDULED).count()
-        context["recent_campaigns"] = active_campaigns.order_by('-created_at')[:5]
-        context["upcoming_campaigns"] = active_campaigns.filter(status=Campaign.Status.SCHEDULED).order_by('send_at')[:5]
+        context["page_title"] = self.get_page_title()
+        context["admin_nav"] = self.get_admin_navigation()
+        context["active_section"] = self.section
+        return context
 
-        # Email performance analytics
-        context["total_emails_sent"] = EmailMessageLog.objects.filter(status=EmailMessageLog.Status.SENT).count()
-        context["emails_delivered"] = EmailMessageLog.objects.filter(status=EmailMessageLog.Status.DELIVERED).count()
-        context["emails_opened"] = EmailMessageLog.objects.filter(status=EmailMessageLog.Status.OPENED).count()
-        context["emails_clicked"] = EmailMessageLog.objects.filter(status=EmailMessageLog.Status.CLICKED).count()
-        context["emails_bounced"] = EmailMessageLog.objects.filter(status=EmailMessageLog.Status.BOUNCED).count()
-        
-        # Calculate rates
-        if context["total_emails_sent"] > 0:
-            context["delivery_rate"] = round((context["emails_delivered"] / context["total_emails_sent"]) * 100, 2)
-            context["open_rate"] = round((context["emails_opened"] / context["total_emails_sent"]) * 100, 2)
-            context["click_rate"] = round((context["emails_clicked"] / context["total_emails_sent"]) * 100, 2)
-            context["bounce_rate"] = round((context["emails_bounced"] / context["total_emails_sent"]) * 100, 2)
-        else:
-            context["delivery_rate"] = 0
-            context["open_rate"] = 0
-            context["click_rate"] = 0
-            context["bounce_rate"] = 0
-        
-        # Recent activity
-        context["recent_emails"] = EmailMessageLog.objects.select_related(
-            'subscriber', 'campaign', 'drip_step'
-        ).order_by('-sent_at')[:10]
 
-        context["drip_overview"] = [
+class NewsletterDashboardView(NewsletterAdminMixin, TemplateView):
+    template_name = "newsletter/admin/dashboard.html"
+    section = "dashboard"
+    page_title = "Newsletter overview"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        lists = SubscriptionList.objects.order_by("name")
+        total_subscriptions = Subscription.objects.select_related("subscription_list").count()
+        active_subscriptions = Subscription.objects.filter(status=Subscription.Status.ACTIVE).count()
+        pending_subscriptions = Subscription.objects.filter(status=Subscription.Status.PENDING).count()
+        status_breakdown = {
+            item["status"]: item["total"]
+            for item in Subscription.objects.values("status").annotate(total=Count("id"))
+        }
+
+        campaigns = Campaign.objects.filter(archived=False)
+        total_campaigns = campaigns.count()
+        recent_campaigns = campaigns.select_related("email_template").prefetch_related("lists").order_by("-created_at")[:5]
+        upcoming_campaigns = campaigns.filter(status=Campaign.Status.SCHEDULED).order_by("send_at")[:5]
+
+        email_totals = {
+            "sent": EmailMessageLog.objects.filter(status=EmailMessageLog.Status.SENT).count(),
+            "delivered": EmailMessageLog.objects.filter(status=EmailMessageLog.Status.DELIVERED).count(),
+            "opened": EmailMessageLog.objects.filter(status=EmailMessageLog.Status.OPENED).count(),
+            "clicked": EmailMessageLog.objects.filter(status=EmailMessageLog.Status.CLICKED).count(),
+            "bounced": EmailMessageLog.objects.filter(status=EmailMessageLog.Status.BOUNCED).count(),
+        }
+
+        total_emails_sent = email_totals["sent"] or 1
+        delivery_rate = round((email_totals["delivered"] / total_emails_sent) * 100, 2)
+        open_rate = round((email_totals["opened"] / total_emails_sent) * 100, 2)
+        click_rate = round((email_totals["clicked"] / total_emails_sent) * 100, 2)
+        bounce_rate = round((email_totals["bounced"] / total_emails_sent) * 100, 2)
+
+        recent_emails = (
+            EmailMessageLog.objects.select_related("subscriber", "campaign", "drip_step")
+            .order_by("-sent_at")[:10]
+        )
+
+        drips = (
+            DripCampaign.objects.filter(archived=False)
+            .select_related("subscription_list")
+            .prefetch_related("steps")
+        )
+
+        thirty_days_ago = timezone.now() - timedelta(days=30)
+        new_subscriptions_30d = Subscription.objects.filter(created_at__gte=thirty_days_ago).count()
+        active_subscriptions_30d = Subscription.objects.filter(
+            status=Subscription.Status.ACTIVE,
+            created_at__gte=thirty_days_ago,
+        ).count()
+
+        context.update(
             {
-                "id": drip.pk,
-                "name": drip.name,
-                "enabled": drip.enabled,
-                "archived": drip.archived,
-                "list": drip.subscription_list.name,
-                "steps": list(drip.steps.order_by("order").values("order", "title", "offset_days", "offset_weeks")),
+                "lists": lists,
+                "total_subscriptions": total_subscriptions,
+                "active_subscriptions": active_subscriptions,
+                "pending_subscriptions": pending_subscriptions,
+                "status_breakdown": status_breakdown,
+                "campaigns_total": total_campaigns,
+                "recent_campaigns": recent_campaigns,
+                "upcoming_campaigns": upcoming_campaigns,
+                "recent_emails": recent_emails,
+                "drips": drips,
+                "new_subscriptions_30d": new_subscriptions_30d,
+                "active_subscriptions_30d": active_subscriptions_30d,
+                "performance_chart": {
+                    "labels": ["Delivered", "Opened", "Clicked", "Bounced"],
+                    "values": [
+                        email_totals["delivered"],
+                        email_totals["opened"],
+                        email_totals["clicked"],
+                        email_totals["bounced"],
+                    ],
+                },
+                "delivery_rate": delivery_rate,
+                "open_rate": open_rate,
+                "click_rate": click_rate,
+                "bounce_rate": bounce_rate,
+                "total_emails_sent": email_totals["sent"],
             }
-            for drip in DripCampaign.objects.filter(archived=False).prefetch_related("steps", "subscription_list")
+        )
+        return context
+
+
+class CampaignListView(NewsletterAdminMixin, TemplateView):
+    template_name = "newsletter/admin/campaigns.html"
+    section = "campaigns"
+    page_title = "Campaigns"
+
+    def get_current_campaign(self):
+        campaign_id = self.request.POST.get("campaign_id") or self.request.GET.get("campaign")
+        if campaign_id:
+            return get_object_or_404(Campaign, pk=campaign_id)
+        return None
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        current_campaign = kwargs.get("current_campaign") or self.get_current_campaign()
+        form = kwargs.get("form") or CampaignForm(instance=current_campaign)
+
+        campaigns = (
+            Campaign.objects.select_related("email_template")
+            .prefetch_related("lists")
+            .order_by("-created_at")
+        )
+        paginator = Paginator(campaigns, 12)
+        page_obj = paginator.get_page(self.request.GET.get("page"))
+
+        status_counts = {
+            item["status"]: item["total"]
+            for item in campaigns.values("status").annotate(total=Count("id"))
+        }
+        status_summary = [
+            {"value": value, "label": label, "count": status_counts.get(value, 0)}
+            for value, label in Campaign.Status.choices
         ]
 
-        # Subscription growth (last 30 days)
-        from datetime import timedelta
-        thirty_days_ago = timezone.now() - timedelta(days=30)
-        context["new_subscriptions_30d"] = Subscription.objects.filter(
-            created_at__gte=thirty_days_ago
-        ).count()
-        context["active_subscriptions_30d"] = Subscription.objects.filter(
-            status=Subscription.Status.ACTIVE,
-            created_at__gte=thirty_days_ago
-        ).count()
-        
+        context.update(
+            {
+                "campaign_form": form,
+                "campaigns_page": page_obj,
+                "current_campaign": current_campaign,
+                "templates": EmailTemplate.objects.order_by("name"),
+                "status_counts": status_counts,
+                "status_choices": Campaign.Status.choices,
+                "status_summary": status_summary,
+            }
+        )
         return context
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        campaign = self.get_current_campaign()
+        action = request.POST.get("action", "save")
+
+        if action in {"archive", "restore"} and campaign:
+            campaign.archived = action == "archive"
+            campaign.save(update_fields=["archived", "updated_at"])
+            message = _("Campaign archived.") if campaign.archived else _("Campaign restored.")
+            messages.success(request, message)
+            return redirect(reverse("newsletter:admin-campaigns"))
+
+        form = CampaignForm(request.POST, instance=campaign)
+        if form.is_valid():
+            saved_campaign = form.save()
+            messages.success(
+                request,
+                _("Campaign '{name}' saved successfully.").format(name=saved_campaign.name),
+            )
+            return redirect(f"{reverse('newsletter:admin-campaigns')}?campaign={saved_campaign.pk}")
+
+        context = self.get_context_data(form=form, current_campaign=campaign)
+        return self.render_to_response(context)
+
+
+class SubscriberListView(NewsletterAdminMixin, TemplateView):
+    template_name = "newsletter/admin/subscribers.html"
+    section = "subscribers"
+    page_title = "Subscribers"
+    paginate_by = 25
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        query = self.request.GET.get("q", "").strip()
+        status_filter = self.request.GET.get("status", "")
+        list_filter = self.request.GET.get("list", "")
+
+        subscribers = Subscriber.objects.all().order_by("-created_at")
+        if query:
+            subscribers = subscribers.filter(
+                Q(email__icontains=query)
+                | Q(first_name__icontains=query)
+                | Q(last_name__icontains=query)
+            )
+        if status_filter:
+            subscribers = subscribers.filter(subscriptions__status=status_filter)
+        if list_filter:
+            subscribers = subscribers.filter(subscriptions__subscription_list_id=list_filter)
+
+        subscribers = subscribers.prefetch_related("subscriptions__subscription_list").distinct()
+        paginator = Paginator(subscribers, self.paginate_by)
+        page_obj = paginator.get_page(self.request.GET.get("page"))
+
+        status_counts = {
+            item["status"]: item["total"]
+            for item in Subscription.objects.values("status").annotate(total=Count("id"))
+        }
+        status_summary = [
+            {"value": value, "label": label, "count": status_counts.get(value, 0)}
+            for value, label in Subscription.Status.choices
+        ]
+
+        context.update(
+            {
+                "subscribers_page": page_obj,
+                "query": query,
+                "status_filter": status_filter,
+                "list_filter": list_filter,
+                "list_filter_value": str(list_filter or ""),
+                "status_counts": status_counts,
+                "status_choices": Subscription.Status.choices,
+                "status_summary": status_summary,
+                "subscription_lists": SubscriptionList.objects.order_by("name"),
+            }
+        )
+        return context
+
+
+class DripCampaignListView(NewsletterAdminMixin, TemplateView):
+    template_name = "newsletter/admin/drips.html"
+    section = "drips"
+    page_title = "Drip campaigns"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        drips = (
+            DripCampaign.objects.select_related("subscription_list")
+            .prefetch_related("steps")
+            .order_by("subscription_list__name", "name")
+        )
+
+        context.update(
+            {
+                "drips": drips,
+                "active_drip_count": drips.filter(enabled=True, archived=False).count(),
+                "archived_drip_count": drips.filter(archived=True).count(),
+            }
+        )
+        return context
+
+
+class TemplateEditorView(NewsletterAdminMixin, TemplateView):
+    template_name = "newsletter/admin/editor.html"
+    section = "editor"
+    page_title = "Newsletter editor"
+
+    def get_current_template(self):
+        template_id = self.request.POST.get("template_id") or self.request.GET.get("template")
+        if template_id:
+            return get_object_or_404(EmailTemplate, pk=template_id)
+        return None
+
+    def get_preview_context(self):
+        subscriber = SimpleNamespace(
+            first_name="Jamie",
+            last_name="Rivera",
+            email="jamie@example.com",
+            full_name="Jamie Rivera",
+        )
+        subscription_list = SimpleNamespace(name="Sample List")
+
+        class DummySubscription:
+            def __init__(self, sub, lst):
+                self.subscriber = sub
+                self.subscription_list = lst
+
+            def build_unsubscribe_url(self):
+                return "#"
+
+        subscription = DummySubscription(subscriber, subscription_list)
+        return {
+            "subscriber": subscriber,
+            "subscription": subscription,
+            "list": subscription_list,
+            "unsubscribe_url": "#",
+            "campaign": SimpleNamespace(name="Sample Campaign"),
+        }
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        current_template = kwargs.get("current_template") or self.get_current_template()
+        form = kwargs.get("form") or EmailTemplateForm(instance=current_template)
+
+        plain_text_preview = ""
+        plain_text_error = ""
+        if current_template:
+            try:
+                plain_text_preview = current_template.render_plain_text(self.get_preview_context())
+            except Exception as exc:  # pragma: no cover - render errors reported to UI
+                plain_text_error = str(exc)
+
+        context.update(
+            {
+                "template_form": form,
+                "templates": EmailTemplate.objects.order_by("name"),
+                "current_template": current_template,
+                "plain_text_preview": plain_text_preview,
+                "plain_text_error": plain_text_error,
+            }
+        )
+        return context
+
+    def post(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        current_template = self.get_current_template()
+        form = EmailTemplateForm(request.POST, instance=current_template)
+
+        if form.is_valid():
+            saved_template = form.save()
+            messages.success(
+                request,
+                _("Template '{name}' saved successfully.").format(name=saved_template.name),
+            )
+            return redirect(f"{reverse('newsletter:admin-editor')}?template={saved_template.pk}")
+
+        context = self.get_context_data(form=form, current_template=current_template)
+        return self.render_to_response(context)


### PR DESCRIPTION
## Summary
- introduce a standalone newsletter admin mixin with dedicated dashboard, campaign, subscriber, drip, and editor views
- add reusable admin base template plus tailored pages, including a Trix-powered editor and plain-text preview workflow
- expose the new interface at /newsletter/admin/ and reuse new plain-text helpers when rendering emails

## Testing
- python manage.py test newsletter

------
https://chatgpt.com/codex/tasks/task_e_68d98e6c09588325a1f265f409f96d92